### PR TITLE
Fix treating falsy values as errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,10 @@
 const flatten = source => (start, sink) => {
   if (start !== 0) return;
-  const exists = x => typeof x !== 'undefined';
-  const absent = x => typeof x === 'undefined';
   let outerEnded = false;
   let outerTalkback;
   let innerTalkback;
-  function talkback(t,d) {
-    if (t === 1) (innerTalkback || outerTalkback)(1,d);
+  function talkback(t, d) {
+    if (t === 1) (innerTalkback || outerTalkback)(1, d);
     if (t === 2) {
       innerTalkback && innerTalkback(2);
       outerTalkback && outerTalkback(2);
@@ -24,19 +22,20 @@ const flatten = source => (start, sink) => {
           innerTalkback = d;
           innerTalkback(1);
         } else if (t === 1) sink(1, d);
-        else if (t === 2 && absent(d)) {
+        else if (t === 2 && d) sink(2, d);
+        else if (t === 2) {
           if (outerEnded) sink(2);
           else {
             innerTalkback = void 0;
             outerTalkback(1);
           }
         }
-        else if (t === 2 && exists(d)) sink(2, d);
       });
-    } else if (T === 2 && absent(D)) {
+    } else if (T === 2 && D) sink(2, D);
+    else if (T === 2) {
       if (!innerTalkback) sink(2);
       else outerEnded = true;
-    } else if (T === 2 && exists(D)) sink(2, D);
+    }
   });
 };
 


### PR DESCRIPTION
According to the callbag spec:
> when the first argument is 2 and the second argument is either undefined (signalling termination due to success) or any truthy value (signalling termination due to failure).

So this "fix" is slightly far fetched because only non spec-compliant values were "broken". I still believe it's better to reverse the logic (like in this PR) & check for `data` being a truthy value first. That way we ensure that spec-compliant values will be treated as errors & non-spec values will get simply swallowed (instead of "breaking" things).

PS. I might send up some more PRs to this repo later in following days (regarding other issues around passing through unknown types and maybe some more).