### PR TITLE
Remove redundant `outerEnded` to shave some bytes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,12 @@
 const flatten = source => (start, sink) => {
   if (start !== 0) return;
-  let outerEnded = false;
   let outerTalkback;
   let innerTalkback;
   function talkback(t, d) {
     if (t === 1) (innerTalkback || outerTalkback)(1, d);
     if (t === 2) {
       innerTalkback && innerTalkback(2);
-      if (!outerEnded) outerTalkback(2);
+      outerTalkback && outerTalkback(2);
     }
   }
   source(0, (T, D) => {
@@ -26,7 +25,7 @@ const flatten = source => (start, sink) => {
           outerTalkback(2);
           sink(2, d);
         } else if (t === 2) {
-          if (outerEnded) sink(2);
+          if (!outerTalkback) sink(2);
           else {
             innerTalkback = void 0;
             outerTalkback(1);
@@ -38,7 +37,7 @@ const flatten = source => (start, sink) => {
       sink(2, D);
     } else if (T === 2) {
       if (!innerTalkback) sink(2);
-      else outerEnded = true;
+      else outerTalkback = void 0;
     }
   });
 };


### PR DESCRIPTION
Follow up to https://github.com/staltz/callbag-flatten/pull/13#issuecomment-716442864

The previous version minifies to:
```js
export default e=>(t,f)=>{if(0!==t)return;let i,l,n=!1;function o(e,t){1===e&&(l||i)(1,t),2===e&&(l&&l(2),n||i(2))}e(0,((e,t)=>{if(0===e)i=t,f(0,o);else if(1===e){const e=t;l&&l(2),e(0,((e,t)=>{0===e?(l=t,l(1)):1===e?f(1,t):2===e&&t?(i(2),f(2,t)):2===e&&(n?f(2):(l=void 0,i(1)))}))}else 2===e&&t?(l&&l(2),f(2,t)):2===e&&(l?n=!0:f(2))}))};
```
whereas the new one minifies to:
```js
export default e=>(i,t)=>{if(0!==i)return;let f,o;function l(e,i){1===e&&(o||f)(1,i),2===e&&(o&&o(2),f&&f(2))}e(0,((e,i)=>{if(0===e)f=i,t(0,l);else if(1===e){const e=i;o&&o(2),e(0,((e,i)=>{0===e?(o=i,o(1)):1===e?t(1,i):2===e&&i?(f(2),t(2,i)):2===e&&(f?(o=void 0,f(1)):t(2))}))}else 2===e&&i?(o&&o(2),t(2,i)):2===e&&(o?f=void 0:t(2))}))};
```
So the new one is 1 character shorter (338 -> 337) but it also compresses slightly better (218 bytes -> 206 bytes) which I've tested with:
```sh
npx terser -cm --toplevel index.js | gzip -c | wc -c
```